### PR TITLE
Several fixes

### DIFF
--- a/git_check_rebase/check_rebase_meta.py
+++ b/git_check_rebase/check_rebase_meta.py
@@ -41,7 +41,7 @@ class Feature:
             assert not self.drop
             self.drop = 'drop'
         else:
-            key, val = [x.strip() for x in prop.split(':', 2)]
+            key, val = [x.strip() for x in prop.split(':', 1)]
             assert val
             if key == 'drop':
                 self.drop = 'drop-' + val
@@ -177,7 +177,7 @@ class Meta:
                         current_obj = None
                         del groups_stack[-1]
                     else:
-                        key, val = [x.strip() for x in line.split(':', 2)]
+                        key, val = [x.strip() for x in line.split(':', 1)]
                         if key == '%feature':
                             current_obj = Feature(val)
                         else:

--- a/git_check_rebase/compare_commits.py
+++ b/git_check_rebase/compare_commits.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Tuple
 from tempfile import mkstemp
 
-from .simple_git import git, git_get_git_dir, git_log1, git_log
+from .simple_git import git, git_get_git_dir, git_log1, git_log, git_commit_exists
 
 eat_numbers_subs = tuple((re.compile(a, re.MULTILINE), b) for a, b in
                          (
@@ -86,6 +86,16 @@ def are_commits_equal(c1: str, c2: str, ignore_cmsg: bool) -> bool:
 
     e = CACHE.get(c1, c2)
     if e is None:
+        c1_exists = git_commit_exists(c1)
+        if not c1_exists:
+            print(f'Commit {c1} does not exist')
+            return False
+        c2_exists = git_commit_exists(c2)
+        if not c2_exists:
+            print(f'Commit {c2} does not exist')
+            return False
+
+
         c1_text = eat_numbers(git('show --format= ' + c1))
         c2_text = eat_numbers(git('show --format= ' + c2))
 

--- a/git_check_rebase/compare_ranges.py
+++ b/git_check_rebase/compare_ranges.py
@@ -339,13 +339,12 @@ class Table:
 
         for row_ind, row in enumerate(self.rows):
             if rows_hide_level.value >= RowsHideLevel.HIDE_CHECKED.value and \
-                    all(c is not None and c.comp != CompRes.NONE for
-                        c in row.commits):
+                    all(c.comp != CompRes.NONE for
+                        c in row.commits if c is not None):
                 continue
             if rows_hide_level.value >= RowsHideLevel.HIDE_EQUAL.value and \
-                    all(c is not None and
-                        c.comp in (CompRes.BASE, CompRes.EQUAL) for
-                        c in row.commits):
+                    all(c.comp in (CompRes.BASE, CompRes.EQUAL) for
+                        c in row.commits if c is not None):
                 continue
 
             line = row.to_list(columns, {

--- a/git_check_rebase/simple_git.py
+++ b/git_check_rebase/simple_git.py
@@ -38,3 +38,10 @@ def git_log_table(fmt, param, splitter='$%^@'):
 
 def git_get_git_dir():
     return git('rev-parse --git-common-dir').strip()
+
+def git_commit_exists(rev):
+    try:
+        git('rev-parse --verify ' + rev, stderr=subprocess.DEVNULL)
+        return True
+    except subprocess.CalledProcessError:
+        return False


### PR DESCRIPTION
commit 7a072f10e3269317e170d9568bcf89dbecccb7d4 (HEAD -> fixes, fork/fixes)
Author: Oleg Vasilev <me@svin.in>
Date:   Sun Apr 9 16:48:30 2023 +0600

    Ignore unexisting commits from meta file

    This can happen when there was a rebase after git-check-rebase is done.

    Signed-off-by: Oleg Vasilev <me@svin.in>

commit c5cad183ccf285cb5f6b116cbc4bab32e4553d78
Author: Oleg Vasilev <me@svin.in>
Date:   Sun Apr 9 16:22:35 2023 +0600

    Omit absent commits during for hide_checked condition

    Suppose we have a "base" range. Many commits are not present there, so this will
    count as "not checked", but the truth is that those a simply not upstreamed.

    Signed-off-by: Oleg Vasilev <me@svin.in>

commit 1ec7f97416fae838641840de8ae63f261af9a4d5
Author: Oleg Vasilev <oleg.vasilev@virtuozzo.com>
Date:   Tue Feb 28 12:11:24 2023 +0600

    Fix pair unpacking during meta file parsing

    If we have an extra ":" in drop or feature comment, like:
      %drop: no need: already done
    The program will crash. prop.split(':', 1) will make at most 1 split.

    Signed-off-by: Oleg Vasilev <oleg.vasilev@virtuozzo.com>
